### PR TITLE
(fix) Handle nosuchbucket error on s3 check-public-block filter

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -434,8 +434,8 @@ class AnnotationSweeper:
         self.resource_map = resource_map
 
     def sweep(self, resources):
-        for rid in set(self.ra_map).difference([
-            r[self.id_key] for r in resources]):
+        for rid in set(self.ra_map).difference(
+                [r[self.id_key] for r in resources]):
             # Clear annotations if the block filter didn't match
             akeys = [k for k in self.resource_map[rid] if k.startswith('c7n')]
             for k in akeys:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1424,7 +1424,12 @@ class FilterPublicBlock(Filter):
                 config = s3.get_public_access_block(
                     Bucket=bucket['Name'])['PublicAccessBlockConfiguration']
             except ClientError as e:
-                if e.response['Error']['Code'] != 'NoSuchPublicAccessBlockConfiguration':
+                # Since we run policies in a specific region, it is possible that the s3
+                # client initialized only has access to one region's buckets, whereas
+                # c7n attempts to process the global list of buckets, so we ignore any
+                # NoSuchBucket errors
+                if e.response['Error']['Code'] != 'NoSuchPublicAccessBlockConfiguration' \
+                        or e.response['Error']['Code'] != 'NoSuchBucket':
                     raise
             bucket[self.annotation_key] = config
         return self.matches_filter(config)

--- a/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
+++ b/tools/c7n_gcp/c7n_gcp/filters/iampolicy.py
@@ -47,7 +47,7 @@ class IamPolicyFilter(Filter):
             op = 'in' if user_role.get('has', True) else 'not-in'
             value_type = 'swap'
             userRolePairFilter = IamPolicyUserRolePairFilter({'key': key, 'value': val,
-                                                              'op': op, 'value_type': value_type}, self.manager)
+                'op': op, 'value_type': value_type}, self.manager)
             resources = userRolePairFilter.process(resources)
 
         return resources

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -42,6 +42,7 @@ class SqlInstance(QueryResourceManager):
         def get_metric_resource_name(resource):
             return "{}:{}".format(resource["project"], resource["name"])
 
+
 @SqlInstance.filter_registry.register('database-flags')
 class DatabaseFlagsFilter(ValueFilter):
     """Filters a SQL instance by its database flags.
@@ -62,7 +63,6 @@ class DatabaseFlagsFilter(ValueFilter):
 
     schema = type_schema('database-flags', rinherit=ValueFilter.schema)
     #     permissions = ('cloudsql.databases.list',)
-
 
     def process(self, resources, event=None):
 


### PR DESCRIPTION
As buckets in an account are available across all regions, C7n first grabs the global list of buckets, but since we run policies in a specific region (with the --region flag) the s3 client initialized may only has access to one region's buckets, resulting in an insignificant NoSuchBucket error