### PR TITLE
(fix) Fix AWS iam-policy resource has-allow-all filter

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -17,7 +17,6 @@ from dateutil.parser import parse as parse_date
 
 from botocore.exceptions import ClientError
 
-
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import ValueFilter, Filter
@@ -55,7 +54,6 @@ class DescribeGroup(DescribeSource):
 
 @resources.register('iam-group')
 class Group(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'group'
@@ -91,7 +89,6 @@ class DescribeRole(DescribeSource):
 
 @resources.register('iam-role')
 class Role(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'role'
@@ -116,7 +113,6 @@ Role.filter_registry.register('marked-for-op', TagActionFilter)
 
 @Role.action_registry.register('post-finding')
 class RolePostFinding(OtherResourcePostFinding):
-
     resource_type = 'AwsIamRole'
 
     def format_resource(self, r):
@@ -243,7 +239,6 @@ class DescribeUser(DescribeSource):
 
 @resources.register('iam-user')
 class User(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'user'
@@ -295,7 +290,6 @@ class UserRemoveTag(RemoveTag):
 User.action_registry.register('mark-for-op', TagDelayedAction)
 User.filter_registry.register('marked-for-op', TagActionFilter)
 
-
 Role.action_registry.register('mark-for-op', TagDelayedAction)
 Role.filter_registry.register('marked-for-op', TagActionFilter)
 
@@ -332,7 +326,7 @@ class SetGroups(BaseAction):
     def validate(self):
         if self.data.get('group') == '':
             raise PolicyValidationError('group cannot be empty on %s'
-                % (self.manager.data))
+                                        % (self.manager.data))
 
     def process(self, resources):
         group_name = self.data['group']
@@ -391,7 +385,6 @@ class DescribePolicy(DescribeSource):
 
 @resources.register('iam-policy')
 class Policy(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'policy'
@@ -411,7 +404,6 @@ class Policy(QueryResourceManager):
 
 
 class PolicyQueryParser(QueryParser):
-
     QuerySchema = {
         'Scope': ('All', 'AWS', 'Local'),
         'PolicyUsageFilter': ('PermissionsPolicy', 'PermissionsBoundary'),
@@ -424,7 +416,6 @@ class PolicyQueryParser(QueryParser):
 
 @resources.register('iam-profile')
 class InstanceProfile(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'instance-profile'
@@ -438,7 +429,6 @@ class InstanceProfile(QueryResourceManager):
 
 @resources.register('iam-certificate')
 class ServerCertificate(QueryResourceManager):
-
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'server-certificate'
@@ -767,7 +757,7 @@ class CheckPermissions(Filter):
             else:
                 values = ['allowed']
             vf = ValueFilter({'type': 'value', 'key':
-                              'EvalDecision', 'value': values,
+                'EvalDecision', 'value': values,
                               'op': 'in'})
         else:
             vf = ValueFilter(self.data['match'])
@@ -834,7 +824,7 @@ class IamRoleUsage(Filter):
     def scan_asg_roles(self):
         manager = self.manager.get_resource_manager('launch-config')
         return [r['IamInstanceProfile'] for r in manager.resources() if (
-            'IamInstanceProfile' in r)]
+                'IamInstanceProfile' in r)]
 
     def scan_ec2_roles(self):
         manager = self.manager.get_resource_manager('ec2')
@@ -881,10 +871,10 @@ class UsedIamRole(IamRoleUsage):
         roles = self.service_role_usage()
         if self.data.get('state', True):
             return [r for r in resources if (
-                r['Arn'] in roles or r['RoleName'] in roles)]
+                    r['Arn'] in roles or r['RoleName'] in roles)]
 
         return [r for r in resources if (
-            r['Arn'] not in roles and r['RoleName'] not in roles)]
+                r['Arn'] not in roles and r['RoleName'] not in roles)]
 
 
 @Role.filter_registry.register('unused')
@@ -916,7 +906,6 @@ class UnusedIamRole(IamRoleUsage):
 
 @Role.filter_registry.register('cross-account')
 class RoleCrossAccountAccess(CrossAccountAccessFilter):
-
     policy_attribute = 'AssumeRolePolicyDocument'
     permissions = ('iam:ListRoles',)
 
@@ -1028,7 +1017,7 @@ class NoSpecificIamRoleManagedPolicy(Filter):
         c = local_session(self.manager.session_factory).client('iam')
         if self.data.get('value'):
             return [r for r in resources if not self.data.get('value') in
-            self._managed_policies(c, r)]
+                                                self._managed_policies(c, r)]
         return []
 
 
@@ -1185,7 +1174,7 @@ class RoleDelete(BaseAction):
                 self.log.warning(
                     ("Role:%s cannot be deleted, set force "
                      "to detach policy, instance profile and delete, error: %s") % (
-                         r['Arn'], str(e)))
+                        r['Arn'], str(e)))
                 error = e
             except (client.exceptions.NoSuchEntityException,
                     client.exceptions.UnmodifiableEntityException):
@@ -1302,14 +1291,14 @@ class AllowAllIamPolicies(Filter):
 
         for s in statements:
             if ('Condition' not in s and
-                    ('Action' in s and
-                     (isinstance(s['Action'], str) and
-                    s['Action'] == "*") or
+                    'Action' in s and
+                    ((isinstance(s['Action'], str) and
+                      s['Action'] == "*") or
                      (isinstance(s['Action'], list)
-                      and "*" in s['action'])) and
-                    ('Resource' in s and
-                     (isinstance(s['Resource'], str) and
-                    s['Resource'] == "*") or
+                      and "*" in s['Action'])) and
+                    'Resource' in s and
+                    ((isinstance(s['Resource'], str) and
+                      s['Resource'] == "*") or
                      (isinstance(s['Resource'], list)
                       and "*" in s['Resource'])) and
                     s['Effect'] == "Allow"):
@@ -2179,7 +2168,7 @@ class UserDelete(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('iam')
         self.log.debug('Deleting user %s options: %s' %
-            (len(resources), self.data.get('options', 'all')))
+                       (len(resources), self.data.get('options', 'all')))
         for r in resources:
             self.process_user(client, r)
 
@@ -2444,7 +2433,7 @@ class GroupInlinePolicyDelete(BaseAction):
         for policy in r.get('c7n:InlinePolicies', []):
             try:
                 self.manager.retry(client.delete_group_policy,
-                    GroupName=r['GroupName'], PolicyName=policy)
+                                   GroupName=r['GroupName'], PolicyName=policy)
             except client.exceptions.NoSuchEntityException:
                 continue
 
@@ -2549,7 +2538,6 @@ class SamlProvider(QueryResourceManager):
     """
 
     class resource_type(TypeInfo):
-
         service = 'iam'
         name = id = 'Arn'
         enum_spec = ('list_saml_providers', 'SAMLProviderList', None)
@@ -2569,9 +2557,7 @@ class OpenIdDescribe(DescribeSource):
 
 @resources.register('iam-oidc-provider')
 class OpenIdProvider(QueryResourceManager):
-
     class resource_type(TypeInfo):
-
         service = 'iam'
         name = id = 'Arn'
         enum_spec = ('list_open_id_connect_providers', 'OpenIDConnectProviderList', None)

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1302,12 +1302,16 @@ class AllowAllIamPolicies(Filter):
 
         for s in statements:
             if ('Condition' not in s and
-                    'Action' in s and
-                    isinstance(s['Action'], str) and
-                    s['Action'] == "*" and
-                    'Resource' in s and
-                    isinstance(s['Resource'], str) and
-                    s['Resource'] == "*" and
+                    ('Action' in s and
+                     (isinstance(s['Action'], str) and
+                    s['Action'] == "*") or
+                     (isinstance(s['Action'], list)
+                      and "*" in s['action'])) and
+                    ('Resource' in s and
+                     (isinstance(s['Resource'], str) and
+                    s['Resource'] == "*") or
+                     (isinstance(s['Resource'], list)
+                      and "*" in s['Resource'])) and
                     s['Effect'] == "Allow"):
                 return True
         return False

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -17,6 +17,7 @@ from dateutil.parser import parse as parse_date
 
 from botocore.exceptions import ClientError
 
+
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import ValueFilter, Filter
@@ -54,6 +55,7 @@ class DescribeGroup(DescribeSource):
 
 @resources.register('iam-group')
 class Group(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'group'
@@ -89,6 +91,7 @@ class DescribeRole(DescribeSource):
 
 @resources.register('iam-role')
 class Role(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'role'
@@ -113,6 +116,7 @@ Role.filter_registry.register('marked-for-op', TagActionFilter)
 
 @Role.action_registry.register('post-finding')
 class RolePostFinding(OtherResourcePostFinding):
+
     resource_type = 'AwsIamRole'
 
     def format_resource(self, r):
@@ -239,6 +243,7 @@ class DescribeUser(DescribeSource):
 
 @resources.register('iam-user')
 class User(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'user'
@@ -290,6 +295,7 @@ class UserRemoveTag(RemoveTag):
 User.action_registry.register('mark-for-op', TagDelayedAction)
 User.filter_registry.register('marked-for-op', TagActionFilter)
 
+
 Role.action_registry.register('mark-for-op', TagDelayedAction)
 Role.filter_registry.register('marked-for-op', TagActionFilter)
 
@@ -326,7 +332,7 @@ class SetGroups(BaseAction):
     def validate(self):
         if self.data.get('group') == '':
             raise PolicyValidationError('group cannot be empty on %s'
-                                        % (self.manager.data))
+                % (self.manager.data))
 
     def process(self, resources):
         group_name = self.data['group']
@@ -385,6 +391,7 @@ class DescribePolicy(DescribeSource):
 
 @resources.register('iam-policy')
 class Policy(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'policy'
@@ -404,6 +411,7 @@ class Policy(QueryResourceManager):
 
 
 class PolicyQueryParser(QueryParser):
+
     QuerySchema = {
         'Scope': ('All', 'AWS', 'Local'),
         'PolicyUsageFilter': ('PermissionsPolicy', 'PermissionsBoundary'),
@@ -416,6 +424,7 @@ class PolicyQueryParser(QueryParser):
 
 @resources.register('iam-profile')
 class InstanceProfile(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'instance-profile'
@@ -429,6 +438,7 @@ class InstanceProfile(QueryResourceManager):
 
 @resources.register('iam-certificate')
 class ServerCertificate(QueryResourceManager):
+
     class resource_type(TypeInfo):
         service = 'iam'
         arn_type = 'server-certificate'
@@ -757,7 +767,7 @@ class CheckPermissions(Filter):
             else:
                 values = ['allowed']
             vf = ValueFilter({'type': 'value', 'key':
-                'EvalDecision', 'value': values,
+                              'EvalDecision', 'value': values,
                               'op': 'in'})
         else:
             vf = ValueFilter(self.data['match'])
@@ -824,7 +834,7 @@ class IamRoleUsage(Filter):
     def scan_asg_roles(self):
         manager = self.manager.get_resource_manager('launch-config')
         return [r['IamInstanceProfile'] for r in manager.resources() if (
-                'IamInstanceProfile' in r)]
+            'IamInstanceProfile' in r)]
 
     def scan_ec2_roles(self):
         manager = self.manager.get_resource_manager('ec2')
@@ -871,10 +881,10 @@ class UsedIamRole(IamRoleUsage):
         roles = self.service_role_usage()
         if self.data.get('state', True):
             return [r for r in resources if (
-                    r['Arn'] in roles or r['RoleName'] in roles)]
+                r['Arn'] in roles or r['RoleName'] in roles)]
 
         return [r for r in resources if (
-                r['Arn'] not in roles and r['RoleName'] not in roles)]
+            r['Arn'] not in roles and r['RoleName'] not in roles)]
 
 
 @Role.filter_registry.register('unused')
@@ -906,6 +916,7 @@ class UnusedIamRole(IamRoleUsage):
 
 @Role.filter_registry.register('cross-account')
 class RoleCrossAccountAccess(CrossAccountAccessFilter):
+
     policy_attribute = 'AssumeRolePolicyDocument'
     permissions = ('iam:ListRoles',)
 
@@ -1017,7 +1028,7 @@ class NoSpecificIamRoleManagedPolicy(Filter):
         c = local_session(self.manager.session_factory).client('iam')
         if self.data.get('value'):
             return [r for r in resources if not self.data.get('value') in
-                                                self._managed_policies(c, r)]
+            self._managed_policies(c, r)]
         return []
 
 
@@ -1174,7 +1185,7 @@ class RoleDelete(BaseAction):
                 self.log.warning(
                     ("Role:%s cannot be deleted, set force "
                      "to detach policy, instance profile and delete, error: %s") % (
-                        r['Arn'], str(e)))
+                         r['Arn'], str(e)))
                 error = e
             except (client.exceptions.NoSuchEntityException,
                     client.exceptions.UnmodifiableEntityException):
@@ -1293,12 +1304,12 @@ class AllowAllIamPolicies(Filter):
             if ('Condition' not in s and
                     'Action' in s and
                     ((isinstance(s['Action'], str) and
-                      s['Action'] == "*") or
+                    s['Action'] == "*") or
                      (isinstance(s['Action'], list)
                       and "*" in s['Action'])) and
                     'Resource' in s and
                     ((isinstance(s['Resource'], str) and
-                      s['Resource'] == "*") or
+                    s['Resource'] == "*") or
                      (isinstance(s['Resource'], list)
                       and "*" in s['Resource'])) and
                     s['Effect'] == "Allow"):
@@ -2168,7 +2179,7 @@ class UserDelete(BaseAction):
     def process(self, resources):
         client = local_session(self.manager.session_factory).client('iam')
         self.log.debug('Deleting user %s options: %s' %
-                       (len(resources), self.data.get('options', 'all')))
+            (len(resources), self.data.get('options', 'all')))
         for r in resources:
             self.process_user(client, r)
 
@@ -2433,7 +2444,7 @@ class GroupInlinePolicyDelete(BaseAction):
         for policy in r.get('c7n:InlinePolicies', []):
             try:
                 self.manager.retry(client.delete_group_policy,
-                                   GroupName=r['GroupName'], PolicyName=policy)
+                    GroupName=r['GroupName'], PolicyName=policy)
             except client.exceptions.NoSuchEntityException:
                 continue
 
@@ -2538,6 +2549,7 @@ class SamlProvider(QueryResourceManager):
     """
 
     class resource_type(TypeInfo):
+
         service = 'iam'
         name = id = 'Arn'
         enum_spec = ('list_saml_providers', 'SAMLProviderList', None)
@@ -2557,7 +2569,9 @@ class OpenIdDescribe(DescribeSource):
 
 @resources.register('iam-oidc-provider')
 class OpenIdProvider(QueryResourceManager):
+
     class resource_type(TypeInfo):
+
         service = 'iam'
         name = id = 'Arn'
         enum_spec = ('list_open_id_connect_providers', 'OpenIDConnectProviderList', None)


### PR DESCRIPTION
Filter previously only checked policies strictly adhering to example in documentation, this fix generalizes it a bit more