### PR TITLE
Handle cache unpickle error (SSPROD-10962)

### DIFF
--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -99,7 +99,7 @@ class FileCacheManager:
             with open(self.cache_path, 'rb') as fh:
                 try:
                     self.data = pickle.load(fh)
-                except EOFError:
+                except (EOFError, pickle.UnpicklingError):
                     return False
             log.debug("Using cache file %s" % self.cache_path)
             return True


### PR DESCRIPTION
Occasionally, some benchmark policies are failing because of `pickle.UnpicklingError`, which is used by cloud custodian's cache. If this error occurs, we can handle it and default to having custodian refetch the data 