### PR TITLE
Fix GCP Cloud SQL database-flags filter

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -67,12 +67,12 @@ class DatabaseFlagsFilter(ValueFilter):
     def process(self, resources, event=None):
 
         for r in resources:
-            if 'databaseFlags' not in r:
+            if 'settings' not in r or 'databaseFlags' not in r['settings'] :
                 r['databaseFlags'] = {}
                 continue
 
             dbFlagMap = {}
-            for flag in r['databaseFlags']:
+            for flag in r['settings']['databaseFlags']:
                 dbFlagMap[flag['name']] = flag['value']
             r['databaseFlags'] = dbFlagMap
         return super(DatabaseFlagsFilter, self).process(resources)

--- a/tools/c7n_gcp/c7n_gcp/resources/sql.py
+++ b/tools/c7n_gcp/c7n_gcp/resources/sql.py
@@ -67,7 +67,7 @@ class DatabaseFlagsFilter(ValueFilter):
     def process(self, resources, event=None):
 
         for r in resources:
-            if 'settings' not in r or 'databaseFlags' not in r['settings'] :
+            if 'settings' not in r or 'databaseFlags' not in r['settings']:
                 r['databaseFlags'] = {}
                 continue
 


### PR DESCRIPTION
Fix for https://sysdig.atlassian.net/browse/SSPROD-11379#icft=SSPROD-11379 (part of https://sysdig.atlassian.net/browse/ESC-1724). 

The database-flags filter was looking for the key `databaseFlags` at the top level of the resource, however this key is actually nested within `settings.databaseFlags`.