### PR TITLE
Fix for Azure 3.8 policy

### DIFF
--- a/tools/c7n_azure/c7n_azure/filters.py
+++ b/tools/c7n_azure/c7n_azure/filters.py
@@ -1015,3 +1015,24 @@ class ParentFilter(Filter):
 
         parent_key = self.manager.resource_type.parent_key
         return [r for r in resources if r[parent_key] in parent_resources_ids]
+
+class ParentNameAsNameFilter(Filter):
+    """
+    Changes a resource's name to display its parent resource's name instead
+    """
+
+    schema = {
+        'type': 'object',
+        'required': [],
+        'additionalProperties': False,
+        'properties': {
+        }
+    }
+
+    def process(self, resources, event=None):
+        for r in resources:
+            if 'c7n:parent-id' in r and 'name' in r:
+                tokens = r['c7n:parent-id'].split('/')
+                r['name'] = tokens[-1]
+
+        return resources

--- a/tools/c7n_azure/c7n_azure/resources/storage.py
+++ b/tools/c7n_azure/c7n_azure/resources/storage.py
@@ -18,8 +18,8 @@ from c7n.utils import get_annotation_prefix, local_session
 from c7n_azure.actions.base import AzureBaseAction
 from c7n_azure.actions.firewall import SetFirewallAction
 from c7n_azure.constants import BLOB_TYPE, FILE_TYPE, QUEUE_TYPE, TABLE_TYPE
-from c7n_azure.filters import (FirewallBypassFilter, FirewallRulesFilter,
-                               ValueFilter)
+from c7n_azure.filters import (FirewallBypassFilter, FirewallRulesFilter, Filter,
+                               ValueFilter, ParentNameAsNameFilter)
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
 from c7n_azure.storage_utils import StorageUtilities
@@ -586,9 +586,6 @@ class StorageBlobServices(ChildArmResourceManager):
         default_report_fields = (
             'name',
             'deleteRetentionPolicy',
-            'isVersioningEnabled',
-            'restorePolicy',
-            'containerDeleteRetentionPolicy',
             '"c7n:parent-id"'
         )
 
@@ -596,3 +593,11 @@ class StorageBlobServices(ChildArmResourceManager):
         def extra_args(cls, parent_resource):
             return {'resource_group_name': parent_resource['resourceGroup'],
                     'account_name': parent_resource['name']}
+
+@StorageBlobServices.filter_registry.register('parent-name-as-name')
+class StorageBlobParentNameAsNameFilter(ParentNameAsNameFilter):
+    schema = type_schema('storage-blobs', rinherit=ValueFilter.schema)
+
+    def __call__(self, i):
+        return super(StorageBlobParentNameAsNameFilter,
+                     self)


### PR DESCRIPTION
Policy checks the `azure.storage-blob-services` (custom resource we created, but needs to report on the actual storage account that contains the blob storage object. Previously name was being reported as `"Default"` since the blob didn't have a name, so we want to put in its parent storage account as the name instead 